### PR TITLE
Fix local registration

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -46,11 +46,19 @@ class AuthController extends Controller
      */
     public function validator(array $data)
     {
-        return Validator::make($data, [
-            'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|confirmed|min:6',
-            'g-recaptcha-response' => 'required|captcha'
-        ]);
+        if (env('APP_ENV') != 'local') {
+            return Validator::make($data, [
+                'email' => 'required|email|max:255|unique:users',
+                'password' => 'required|confirmed|min:6',
+                'g-recaptcha-response' => 'required|captcha'
+            ]);
+        } else {
+            return Validator::make($data, [
+                'email' => 'required|email|max:255|unique:users',
+                'password' => 'required|confirmed|min:6'
+            ]);
+        }
+        
     }
 
     /**

--- a/resources/lang/en_US.utf8/validation.php
+++ b/resources/lang/en_US.utf8/validation.php
@@ -2,6 +2,7 @@
 
 return [
   'phone' => 'The mobile number must be in international format.',
+  'required' => 'Did not complete a required field.',
   'custom' => [
     'name' => [
         'min' => 'Tell us your full name',

--- a/resources/lang/es_AR.utf8/validation.php
+++ b/resources/lang/es_AR.utf8/validation.php
@@ -2,6 +2,7 @@
 
 return [
   'phone' => 'El móvil debe estar en formato internacional sin código de pais, sin espacios ni guiones: Ej. 1132125991',
+  'required' => 'No completo un campo requirido.',
   'custom' => [
     'name' => [
         'min' => 'Dinos tu nombre completo',

--- a/resources/lang/es_ES.utf8/validation.php
+++ b/resources/lang/es_ES.utf8/validation.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+  'phone' => 'El móvil debe estar en formato internacional sin código de pais, sin espacios ni guiones: Ej. 1132125991',
+  'required' => 'No completo un campo requirido.',
   'custom' => [
     'name' => [
         'min' => 'Dinos tu nombre completo',


### PR DESCRIPTION
When registering on a local environment, ```register.blade.php``` indicates that captcha should not be shown. However, it is still a required field and registration fails.

I have removed captcha's requirement from validator method in AuthController if environment is local.

I have also added translations for ```validation.required``` string.
Please advise on the Spanish translations and adjust to your liking.